### PR TITLE
Revert "LGTM前の商品一覧表示機能を削除"

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-
+    @items = Item.includes(:user)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.includes(:user)
+    @items = Item.includes(:user).order('id DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,14 +126,37 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to '#' do %>
-            <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" %>
+      <% if @items != nil %>
+        <%# 商品が出品されている場合に表示 %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to '#' do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" %>
+
+                <%# 商品が売れていればsold outの表示 %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outの表示 %>
 
               </div>
-              <%# //商品が売れていればsold outの表示 %>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+        <%# 商品が出品されている場合に表示 %>
 
       <% else %>
         <%# 商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,34 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
+              <%# 商品が売れていればsold outの表示 %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outの表示 %>
+
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
 
       <%# 商品がない場合のダミー %>
       <%# <li class='list'> %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,19 +132,20 @@
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 
-              <%# 商品が売れていればsold outの表示 %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
               </div>
               <%# //商品が売れていればsold outの表示 %>
 
-            </div>
+      <% else %>
+        <%# 商品がない場合のダミー %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
             <div class='item-info'>
               <h3 class='item-name'>
-                <%= item.name %>
+                商品を出品してね！
               </h3>
               <div class='item-price'>
-                <span><%= item.price %>円<br>(税込み)</span>
+                <span>99999999円<br>(税込み)</span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>
@@ -153,31 +154,14 @@
             </div>
           <% end %>
         </li>
+        <%# //商品がない場合のダミー %>
       <% end %>
-
-      <%# 商品がない場合のダミー %>
-      <%# <li class='list'> %>
-        <%# <%= link_to '#' do %>
-          <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-          <%# <div class='item-info'>
-            <h3 class='item-name'>
-              商品を出品してね！
-            </h3>
-            <div class='item-price'>
-              <span>99999999円<br>(税込み)</span>
-              <div class='star-btn'> %>
-                <%# <%= image_tag "star.png", class:"star-icon" %>
-                <%# <span class='star-count'>0</span>
-              </div>
-            </div>
-          </div> %>
-        <%# <% end %>
-      <%# </li> %>
-      <%# //商品がない場合のダミー %>
     </ul>
   </div>
   <%# //商品一覧 %>
+
 </div>
+
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
   <a href="/items/new">


### PR DESCRIPTION
# What
- 商品一覧表示機能の実装

# Why
- 商品出品機能の実装で出品した商品の一覧表示の為

# Supplement
- 「商品出品機能の実装」で併せて「商品一覧表示機能」を実装してしまっていた為、
商品一覧表示機能の記述を削除して、Branchを分けて再実装いたしました。

- 商品一覧表示画面のリンク
https://gyazo.com/ff0b4100b6b9acf9a86b596817700b64